### PR TITLE
xy-chart supports two lines with different data length

### DIFF
--- a/components/draw/LineChart.vue
+++ b/components/draw/LineChart.vue
@@ -120,8 +120,9 @@ export default {
       const compAttrs = {show: true, fix: true}
       this.rows.comp = compare.map(compareThis =>
         require('~/data/draw/' + compareThis.id + '.json').map(row => {
+          const dataEmpty = row.fix && !row.show
           // have to use fresh empty object
-          return row.empty ? row : Object.assign({}, row, compAttrs)
+          return dataEmpty ? row : Object.assign({}, row, compAttrs)
         })
       )
     }

--- a/components/draw/LineChart.vue
+++ b/components/draw/LineChart.vue
@@ -117,10 +117,12 @@ export default {
       }
     })
     if(compare) {
+      const compAttrs = {show: true, fix: true}
       this.rows.comp = compare.map(compareThis =>
-        require('~/data/draw/' + compareThis.id + '.json').map(row =>
-          Object.assign({}, row, {show: true, fix: true}) // have to use fresh empty object
-        )
+        require('~/data/draw/' + compareThis.id + '.json').map(row => {
+          // have to use fresh empty object
+          return row.empty ? row : Object.assign({}, row, compAttrs)
+        })
       )
     }
   },

--- a/config/draw/tsai-second-year.js
+++ b/config/draw/tsai-second-year.js
@@ -126,10 +126,51 @@ export default {
           formatString: '.1f'
         }
       },
+      compare: [
+        {
+          id: 'annual-visitors-china',
+          label: '中國每年來台旅客人數'
+        }
+      ],
       text: {
         title: '來台旅客有多少',
         before: '政黨輪替後，被視為推展觀光績效的來台旅客人數常被拿出來檢驗，到底蔡英文政府執政的第一年，不分國籍的旅客來台旅客是增加還是減少呢？',
         after: '蔡政府執政第一年，來台旅客**持續增加**中。\n\n根據交通部觀光局[統計數據](http://admin.taiwan.net.tw/statistics/year.aspx?no=134)，民進黨扁政府2007年卸任前來台旅客為371萬人。國民黨馬政府執政後，來台旅客人數持續攀高，至2015年達1,043萬人。2016年民進黨蔡政府執政後，來台旅客人數則持續上升至1,069萬人。'
+      }
+    },
+    {
+      id: 'annual-visitors-china',
+      title: '中國每年來台旅客人數',
+      sheetID: '',
+      speechTarget: {
+        id: 176,
+        speechType: 'musou_line_chart_response'
+      },
+      axes: {
+        x: {
+          divider: 1,
+          unit: 'year',
+          label: '年'
+        },
+        y: {
+          divider: 100000,
+          unit: 'person',
+          label: '萬人',
+          min: 0,
+          max: 4200000,
+          ticks: [0, 1400000, 2800000, 4200000],
+          formatString: 'd'
+        }
+      },
+      sequence: {
+        label: {
+          formatString: '.1f'
+        }
+      },
+      text: {
+        title: '中國每年來台旅客人數',
+        before: '',
+        after: ''
       }
     },
     {

--- a/data/draw/annual-visitors-china.json
+++ b/data/draw/annual-visitors-china.json
@@ -4,64 +4,56 @@
         "y": 0,
         "label": "bian-1",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2001",
         "y": 0,
         "label": "bian-1",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2002",
         "y": 0,
         "label": "bian-1",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2003",
         "y": 0,
         "label": "bian-1",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2004",
         "y": 0,
         "label": "bian-2",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2005",
         "y": 0,
         "label": "bian-2",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2006",
         "y": 0,
         "label": "bian-2",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2007",
         "y": 0,
         "label": "bian-2",
         "show": false,
-        "fix": true,
-        "empty": true
+        "fix": true
     },
     {
         "x": "2008",

--- a/data/draw/annual-visitors-china.json
+++ b/data/draw/annual-visitors-china.json
@@ -1,0 +1,136 @@
+[
+    {
+        "x": "2000",
+        "y": 0,
+        "label": "bian-1",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2001",
+        "y": 0,
+        "label": "bian-1",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2002",
+        "y": 0,
+        "label": "bian-1",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2003",
+        "y": 0,
+        "label": "bian-1",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2004",
+        "y": 0,
+        "label": "bian-2",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2005",
+        "y": 0,
+        "label": "bian-2",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2006",
+        "y": 0,
+        "label": "bian-2",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2007",
+        "y": 0,
+        "label": "bian-2",
+        "show": false,
+        "fix": true,
+        "empty": true
+    },
+    {
+        "x": "2008",
+        "y": "329204",
+        "label": "ma-1",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2009",
+        "y": "972123",
+        "label": "ma-1",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2010",
+        "y": "1630735",
+        "label": "ma-1",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2011",
+        "y": "1784185",
+        "label": "ma-1",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2012",
+        "y": "2586428",
+        "label": "ma-2",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2013",
+        "y": "2874702",
+        "label": "ma-2",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2014",
+        "y": "3987152",
+        "label": "ma-2",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2015",
+        "y": "4184102",
+        "label": "ma-2",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2016",
+        "y": "3511734",
+        "label": "tsai-1",
+        "show": false,
+        "fix": false
+    },
+    {
+        "x": "2017",
+        "y": "2732549",
+        "label": "tsai-1",
+        "show": false,
+        "fix": false
+    }
+]


### PR DESCRIPTION
### DONE
- see `/draw/tsai-second-year` 
- the chart `中國每年來台旅客人數` will not be shown to the public
![image](https://user-images.githubusercontent.com/5423351/40041488-b4010aa8-5850-11e8-9944-648c167220de.png)
