### PR TITLE
fix: not existing module or project should return 404

### DIFF
--- a/pages/_moduleSlug/_projectSlug/index.vue
+++ b/pages/_moduleSlug/_projectSlug/index.vue
@@ -52,6 +52,11 @@ import Journey from '~/components/Journey'
 
 export default {
   mixins: [knowsMarkdown, knowsWatchout],
+  validate({ params }) {
+    const module = modules.find(module => module.id === params.moduleSlug)
+    const project = projects.find(project => project.id === params.projectSlug)
+    return !!module && !!project
+  },
   async asyncData({ params }) {
     let project = projects.find(project => project.id === params.projectSlug)
     let module = modules.find(module => module.id === params.moduleSlug)

--- a/pages/_moduleSlug/index.vue
+++ b/pages/_moduleSlug/index.vue
@@ -22,6 +22,9 @@ import ProjectSignature from '~/components/ProjectSignature'
 
 export default {
   mixins: [knowsWatchout],
+  validate({ params }) {
+    return !!modules.find(module => module.id === params.moduleSlug)
+  },
   async asyncData({ params }) {
     let projectsOfModule = projects.filter(project => project.module === params.moduleSlug)
     let module = modules.find(module => module.id === params.moduleSlug)


### PR DESCRIPTION
### FIXED
- 讓不存在的module or project request回傳404  [ref](https://nuxtjs.org/api/pages-validate/)

> 目前會直接噴500


#### about google crawler
- google會搜尋網站上的robots.txt，static folder下找不到，就會把 `robots.txt` 視為 moduleSlug 去找對應的module
。但 `robots.txt` 當moduleSlug的狀態，應該要回傳404，google那邊才會正常
